### PR TITLE
feat: allow ENDPOINT_URI/COOKIE_DOMAIN to be unset, default to Host: header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+server/.vscode/
+server/__debug_bin
+server/go.sum
+server/server
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run \
 |Variable|Description|Example|
 |-----------------|-----|-----|
 |```ENABLE_DEBUG_OUTPUT```|Set this to true to let the proxy print debug details for setting up or debugging.|false|
-|```ENDPOINT_URI```|URI where the proxy will be reachable at.|www.google.com|
+|```ENDPOINT_URI```|URI where the proxy will be reachable at. If not present, will use `Host` header.|www.google.com|
 |```JS_SUBDIRECTORY```|It is intended to serve the javascript files within a subdirectory of the URI. Here you can define a name for it.|js|
 |```HTML_SUBDIRECTORY```|It is intended to serve the html files (like the GTM iframe) within a subdirectory of the URI. Here you can define a name for it.|html|
 |```GA_CACHE_TIME```|Time in seconds the proxy caches the Google Analytics client javascript.|3600|
@@ -91,7 +91,7 @@ docker run \
 |```ENABLE_SERVER_SIDE_GA_COOKIES```|If the proxy should transfer the client id to a serverside cookie, set this to true.|true|
 |```GA_SERVER_SIDE_COOKIE```|Set the cookie name for the serverside cookie.|_gggp|
 |```GA_CLIENT_SIDE_COOKIE```|Set the cookie name for the clientside cookie, where google analytics will take the client id from.|_ga|
-|```COOKIE_DOMAIN```|The [domain](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Attributes) where the cookies are setup to.|google.com|
+|```COOKIE_DOMAIN```|The [domain](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Attributes) where the cookies are setup to. If not present, use the `Host` header.|google.com|
 |```COOKIE_SECURE```|If your website is accessable through https://, you should set this variable to true. [More info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Secure)|true|
 
 

--- a/server/main.go
+++ b/server/main.go
@@ -101,7 +101,6 @@ func setResponseHeaders(w http.ResponseWriter, headers http.Header) {
 func main() {
 	// Check if required environment variables are set
 	for _, envVar := range [...]string{
-		"ENDPOINT_URI",
 		"JS_SUBDIRECTORY",
 		"GA_PLUGINS_DIRECTORYNAME",
 		"GTM_FILENAME",
@@ -112,7 +111,6 @@ func main() {
 		"GA_COLLECT_ENDPOINT",
 		"GA_COLLECT_REDIRECT_ENDPOINT",
 		"GA_COLLECT_J_ENDPOINT",
-		"COOKIE_DOMAIN",
 	} {
 		if os.Getenv(envVar) == `` {
 			fmt.Println(`ERROR: Seems the required environment variable '` + envVar + `' is missing. Exiting.`)


### PR DESCRIPTION

In some environments a website will have more than one domain name, serving
the same content. This makes it impossible to set ENDPOINT_URI/COOKIE_DOMAIN
as server environment variables.

If ENDPOINT_URI is unset, use Host: header in its place. Update cache
path to be qualified by it.

Allow COOKIE_DOMAIN to be unset.